### PR TITLE
Support hash maps as type 2.0

### DIFF
--- a/swagger/src/main/scala/org/scalatra/swagger/Swagger.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/Swagger.scala
@@ -279,7 +279,7 @@ sealed trait DataType {
 object DataType {
 
   case class ValueDataType(name: String, format: Option[String] = None, qualifiedName: Option[String] = None) extends DataType
-  case class ContainerDataType(name: String, typeArg: Option[DataType] = None, uniqueItems: Boolean = false) extends DataType
+  case class ContainerDataType(name: String, typeArg: Seq[DataType] = Nil, uniqueItems: Boolean = false) extends DataType
 
   val Void = DataType("void")
   val String = DataType("string")
@@ -294,24 +294,24 @@ object DataType {
 
   object GenList {
     def apply(): DataType = ContainerDataType("List")
-    def apply(v: DataType): DataType = new ContainerDataType("List", Some(v))
+    def apply(v: DataType): DataType = new ContainerDataType("List", Seq(v))
   }
 
   object GenSet {
     def apply(): DataType = ContainerDataType("Set", uniqueItems = true)
-    def apply(v: DataType): DataType = new ContainerDataType("Set", Some(v), uniqueItems = true)
+    def apply(v: DataType): DataType = new ContainerDataType("Set", Seq(v), uniqueItems = true)
   }
 
   object GenArray {
     def apply(): DataType = ContainerDataType("Array")
-    def apply(v: DataType): DataType = new ContainerDataType("Array", Some(v))
+    def apply(v: DataType): DataType = new ContainerDataType("Array", Seq(v))
   }
 
-  //  object GenMap {
-  //    def apply(): DataType = Map
-  //    def apply(k: DataType, v: DataType): DataType = new DataType("Map[%s, %s]" format(k.name, v.name))
-  //  }
-  //
+  object GenMap {
+    def apply(): DataType = ContainerDataType("Object")
+    def apply(k: DataType, v: DataType): DataType = new ContainerDataType("Object", Seq(k, v))
+  }
+
   def apply(name: String, format: Option[String] = None, qualifiedName: Option[String] = None) =
     new ValueDataType(name, format, qualifiedName)
   def apply[T](implicit mf: Manifest[T]): DataType = fromManifest[T](mf)
@@ -338,13 +338,12 @@ object DataType {
     else if (isDateTime(klass)) this.DateTime
     else if (isBool(klass)) this.Boolean
     //    else if (classOf[java.lang.Enum[_]].isAssignableFrom(klass)) this.Enum
-    //    else if (isMap(klass)) {
-    //      if (st.typeArgs.size == 2) {
-    //        val (k :: v :: Nil) = st.typeArgs.toList
-    //        GenMap(fromScalaType(k), fromScalaType(v))
-    //      } else GenMap()
-    //    }
-    else if (classOf[scala.collection.Set[_]].isAssignableFrom(klass) || classOf[java.util.Set[_]].isAssignableFrom(klass)) {
+    else if (isMap(klass)) {
+      if (st.typeArgs.size == 2) {
+        val (k :: v :: Nil) = st.typeArgs.toList
+        GenMap(fromScalaType(k), fromScalaType(v))
+      } else GenMap()
+    } else if (classOf[scala.collection.Set[_]].isAssignableFrom(klass) || classOf[java.util.Set[_]].isAssignableFrom(klass)) {
       if (st.typeArgs.nonEmpty) GenSet(fromScalaType(st.typeArgs.head))
       else GenSet()
     } else if (classOf[collection.Seq[_]].isAssignableFrom(klass) || classOf[java.util.List[_]].isAssignableFrom(klass)) {
@@ -373,10 +372,9 @@ object DataType {
   private[this] val DateTimeTypes =
     Set[Class[_]](classOf[JDate], classOf[DateTime])
   private[this] def isDateTime(klass: Class[_]) = DateTimeTypes.exists(_.isAssignableFrom(klass))
-  //
-  //  private[this] def isMap(klass: Class[_]) =
-  //    classOf[collection.Map[_, _]].isAssignableFrom(klass) ||
-  //    classOf[java.util.Map[_, _]].isAssignableFrom(klass)
+  private[this] def isMap(klass: Class[_]) =
+    classOf[collection.Map[_, _]].isAssignableFrom(klass) ||
+      classOf[java.util.Map[_, _]].isAssignableFrom(klass)
 
   private[this] def isCollection(klass: Class[_]) =
     classOf[collection.Traversable[_]].isAssignableFrom(klass) ||

--- a/swagger/src/main/scala/org/scalatra/swagger/SwaggerBase.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/SwaggerBase.scala
@@ -111,8 +111,10 @@ trait SwaggerBaseBase extends Initializable with ScalatraBase { self: JsonSuppor
         List(("$ref" -> s"#/definitions/${t.name}"))
       case t: ValueDataType =>
         List(("type" -> t.name), ("format" -> t.format))
+      case t: ContainerDataType if t.name.toLowerCase == "object" =>
+        List(("type" -> "object"), ("additionalProperties" -> t.typeArg.drop(1).headOption.map(generateDataType)))
       case t: ContainerDataType =>
-        List(("type" -> "array"), ("items" -> generateDataType(t.typeArg.get)))
+        List(("type" -> "array"), ("items" -> t.typeArg.headOption.map(generateDataType)))
     }
   }
 

--- a/swagger/src/main/scala/org/scalatra/swagger/SwaggerSupport.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/SwaggerSupport.scala
@@ -185,13 +185,13 @@ object SwaggerSupportSyntax {
 
     def multiValued: this.type = {
       dataType match {
-        case dt: ValueDataType => dataType(ContainerDataType("List", Some(dt), uniqueItems = false))
+        case dt: ValueDataType => dataType(ContainerDataType("List", Seq(dt), uniqueItems = false))
         case _ => this
       }
     }
     def singleValued: this.type = {
       dataType match {
-        case ContainerDataType(_, Some(dataType), _) => this.dataType(dataType)
+        case ContainerDataType(_, Seq(dataType), _) => this.dataType(dataType)
         case _ => this
       }
     }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.5.1"
+version in ThisBuild := "2.5.1.2-coveo"


### PR DESCRIPTION
Adds support to Maps of type `[String, Any]`, including more specific value types. The 2.0 spec always assume the `String` key type.